### PR TITLE
Change group ID for `android-permissions` library

### DIFF
--- a/VERSIONS.gradle
+++ b/VERSIONS.gradle
@@ -140,7 +140,7 @@ ext {
 
     libs = [
         reactNative: [group: 'com.facebook.react', name: 'react-native', version: getReactNativeLibVersion()],
-        permissions: [group: 'com.intentfilter', name: 'android-permissions', version: '0.1.7'],
+        permissions: [group: 'io.github.nishkarsh', name: 'android-permissions', version: '0.1.7'],
         logback: [group: 'com.github.tony19', name: 'logback-android', version: '1.1.1-9'],
         slf4j: [group: 'org.slf4j', name: 'slf4j-api', version: '1.7.21'],
         promise: [group: 'com.github.jparkie', name: 'promise', version: '1.0.3'],


### PR DESCRIPTION
https://github.com/nishkarsh/android-permissions#readme

> The migration of artifacts to Maven Central is currently under progress. The newer builds would be published under group id io.github.nishkarsh.

Although, according to this comment, older builds should still be available under the old group ID, I was not able to pull this dependency in at the old location. This change allowed things to build again.